### PR TITLE
Add support for webp next generation image format

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const mime = require('mime-types');
 const transform = require('./lib/transform');
 const IIIFError = require('./lib/error');
 
-const filenameRe = new RegExp('(color|gray|bitonal|default)\.(jpg|tif|gif|png)'); // eslint-disable-line no-useless-escape
+const filenameRe = new RegExp('(color|gray|bitonal|default)\.(jpg|tif|gif|png|webp)'); // eslint-disable-line no-useless-escape
 
 function parseUrl (url) {
   var result = {};

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -8,7 +8,7 @@ const FR = '\\d+(?:\.\\d+)?'; // eslint-disable-line no-useless-escape
 
 const Validators = {
   quality: ['color', 'gray', 'bitonal', 'default'],
-  format: ['jpg', 'tif', 'gif', 'png'],
+  format: ['jpg', 'tif', 'gif', 'png', 'webp'],
   region: ['full', 'square', `pct:${FR},${FR},${FR},${FR}`, `${IR},${IR},${IR},${IR}`],
   size: ['full', 'max', `pct:${FR}`, `${IR},`, `,${IR}`, `\\!?${IR},${IR}`],
   rotation: `\\!?${FR}`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-processor",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "IIIF 2.1 Image API modules for NodeJS",
   "main": "index.js",
   "repository": "https://github.com/nulib/node-iiif",


### PR DESCRIPTION
I wanted to find out if I could add support for the `webp` image format on serverless-iiif. It looks like Sharp supports the format out of the box, so it's just a matter of adding it to the `filenameRe` regex and the format array in this repository, and then one similar change in serverless-iiif. https://github.com/ndlib/serverless-iiif/pull/12. 

Example `webp` image: https://image-iiif.library.nd.edu/iiif/2/002097132%2FBOO_002097132-00a/full/full/0/default.webp

If this looks okay, I can open a second PR on serverless-iiif adding `webp` to the appropriate regex and bump the minimum version for this package in the package.json